### PR TITLE
bugfix: delete qdrant_id when no collision happens on delete operator

### DIFF
--- a/src/data/models.rs
+++ b/src/data/models.rs
@@ -544,7 +544,7 @@ pub struct UserDTOWithVotesAndCards {
     pub visible_email: bool,
     pub created_at: chrono::NaiveDateTime,
     pub total_cards_created: i64,
-    pub cards: Vec<CardMetadataWithVotes>,
+    pub cards: Vec<CardMetadataWithVotesAndFiles>,
     pub total_upvotes_received: i32,
     pub total_downvotes_received: i32,
     pub total_votes_cast: i32,

--- a/src/handlers/card_handler.rs
+++ b/src/handlers/card_handler.rs
@@ -229,8 +229,9 @@ pub async fn delete_card(
         })),
     };
 
-    web::block(move || delete_card_metadata_query(&card_id_inner, pool1.lock().unwrap()))
+    web::block(move || delete_card_metadata_query(card_id_inner, pool1))
         .await?
+        .await
         .map_err(|err| ServiceError::BadRequest(err.message.into()))?;
 
     qdrant
@@ -274,7 +275,7 @@ pub async fn update_card(
         .join(" ")
         .trim_end()
         .to_string();
-    if new_content != card_metadata.content && card_metadata.card_html.is_some() {
+    if new_content != card_metadata.content {
         let soup_text_ref = soup.text();
         let Changeset { diffs, .. } = Changeset::new(&card_metadata.content, &soup_text_ref, " ");
         let mut ret: String = Default::default();


### PR DESCRIPTION
bugfix: will not let you change content even if card_html is none, bugfix: ensure collided cards returned in search is public, feature: return file_id and name for a users cards. Fixes #205, #209, #208